### PR TITLE
Fix operator order: '?:' has lower precedence than '<<'; '<<' will be evaluated first

### DIFF
--- a/picotest.h
+++ b/picotest.h
@@ -161,7 +161,7 @@ namespace detail {
     template <typename Char, typename CharTraits>
     ::std::basic_ostream<Char, CharTraits>& operator<<(
         ::std::basic_ostream<Char, CharTraits>& os, const bool& b) {
-            os << b ? "true" : "false";
+            os << (b ? "true" : "false");
             return os;
     }
 


### PR DESCRIPTION
Noticed this problem [here](https://travis-ci.org/nyanp/tiny-cnn/jobs/125191515#L874).
